### PR TITLE
Changed byte to int

### DIFF
--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  byte myValue = 0;
+  int myValue = 0; // Just a test. Thank you for another great tutorial.
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");


### PR DESCRIPTION
There is a bug in the code where a value from analogRead is set to byte
whilst analogRead is always an int. Pulling for fun. Sparkfun FTW.
