### PR TITLE
changed "byte" declaration to "int"

### DIFF
--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  byte myValue = 0;
+  int myValue = 0;
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");


### PR DESCRIPTION
Variable "myValue" in function "loop()" was erroneously declared as
"byte", which made it incompatible with the "int" return code of
function call analogRead().
This change declares "myValue" as int, thereby fixing the problem