### PR TITLE
Correcting variable declaration from byte to int

### DIFF
--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  byte myValue = 0;
+  int myValue = 0;
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");

--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  int myValue = 0;
+  byte myValue = 0;
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");

--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -27,6 +27,6 @@ void loop()
   Serial.print("The value is: ");
   Serial.println(myValue);
 
-  delay(250);
+  delay(100);
 }
 


### PR DESCRIPTION
The original code has a bug. analogRead retuns an int. This change
corrects the variable mismatch