### PR TITLE
Correction on syntax

### DIFF
--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  byte myValue = 0;
+  int myValue = 0;
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");


### PR DESCRIPTION
The original code has a bug, analogRead returns an int. This change corrects the variable mismatch.