### PR TITLE
Corrected byte to int.

### DIFF
--- a/Github_Tutorial.ino
+++ b/Github_Tutorial.ino
@@ -21,7 +21,7 @@ void setup()
 
 void loop() 
 {
-  byte myValue = 0;
+  int myValue = 0;
   myValue = analogRead(A0);
   
   Serial.print("The value is: ");
@@ -29,4 +29,3 @@ void loop()
 
   delay(250);
 }
-


### PR DESCRIPTION
The original code has a bug. analogRead returns an int. This change corrects the variable mismatch. 